### PR TITLE
Implement scanline IO port

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,18 @@ but I'm not familiar with any haskell testing frameworks, and anyway, writing a 
 It's pretty simple: If you press enter, run the gameboy one step, then exit the ST monad and freeze the gameboy state.
 On the next step, the state is unfrozen.
 
-Anyway, it turned out that my flag logic had a bug - it turned flags on but never turned them off. Pretty easy to see
-in the debugger.
 
 **Current status:** Nearly got my first frame!
-Tetris is stuck in a "wait for vblank" loop.   
-```
-0x02B2:   LD a,0xFF44 ; Load the LCD y location into register A
-          CP 94       ; Compare register A with 0x94
-          JR NZ,02B2  ; If not zero, jump back to 0x02B2
-```
-The value at 0xFF44 is the current LCD line being written. When it gets to 148 (0x94), that's the vblank period.
-I haven't implemented any of these IO registers properly yet.
 
-Also, BGB says HL = 0xCFFF at this point. We've got HL = 0xFFCF. Must have confused a high byte and a low byte.
+- Implemented a mechanism to read and write to IO ports.
+- Implemented interrupts
+- Badly need some tests
 
-**Current questions:** How often do you need to refresh the graphics? Can you get away with once per v-blank, or does it have to
-be once per h-blank?
+Current problem is a crash trying to access 0xFEFF. 
+This is caused by my combo registers having their high and low
+bytes the wrong way around.
+
+**Current questions:**
 I'm concerned that exiting the ST monad too often will impact performance. Maybe the graphics can go _inside_ the ST monad?
 Or maybe I don't have to worry too much. It's only a gameboy, after all.
+Can I 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ On the next step, the state is unfrozen.
 Anyway, it turned out that my flag logic had a bug - it turned flags on but never turned them off. Pretty easy to see
 in the debugger.
 
-**Current status:** Let's say 4% complete.
-Tetris is stuck in a loop again, and I think it's because I haven't done interrupts.
-But maybe I'll try drawing some graphics!
+**Current status:** Nearly got my first frame!
+Tetris is stuck in a "wait for vblank" loop.   
+```
+0x02B2:   LD a,0xFF44 ; Load the LCD y location into register A
+          CP 94       ; Compare register A with 0x94
+          JR NZ,02B2  ; If not zero, jump back to 0x02B2
+```
+The value at 0xFF44 is the current LCD line being written. When it gets to 148 (0x94), that's the vblank period.
+I haven't implemented any of these IO registers properly yet.
+
+Also, BGB says HL = 0xCFFF at this point. We've got HL = 0xFFCF. Must have confused a high byte and a low byte.
 
 **Current questions:** How often do you need to refresh the graphics? Can you get away with once per v-blank, or does it have to
 be once per h-blank?

--- a/app/Debugger.hs
+++ b/app/Debugger.hs
@@ -5,34 +5,20 @@ module Main where
 import CPU
 import CPURunner
 import CPU.Environment
-import CPU.FrozenEnvironment
-import CPU.Instructions
+import CPU.FrozenEnvironment 
+import CPURunner (step)
 import CPU.Types
 import Cartridge
-import Numeric (readHex)
-import Data.Bits (testBit)
+import Viewers (viewCPU, viewStack)
 
+import Control.Monad (liftM)
 import Control.Monad.ST
 import Data.Array
 import Data.Word
 import Text.Printf
 import System.IO
-
-viewCPU :: FrozenCPUEnvironment -> String
-viewCPU cpu = 
-            "A F  B C  D E  H L   SP \n" ++
-    (printf "%02X%02X %02X%02X %02X%02X %02X%02X %04X\n\n" 
-        (frz_a cpu) (frz_f cpu) (frz_b cpu) (frz_c cpu) (frz_d cpu) (frz_e cpu) (frz_h cpu) (frz_l cpu) (frz_sp cpu)) ++
-    (viewFlags $ frz_f cpu) ++
-    "\n" ++
-    (printf "PC = 0x%04X (0x%02X)\n" (frz_pc cpu) (frz_rom00 cpu ! (frz_pc cpu)))
-
-viewFlags :: Word8 -> String
-viewFlags f = 
-    "Flags ZNHC \n" ++ 
-    "      " ++ (b 7) ++ (b 6) ++ (b 5) ++ (b 4) ++ "\n"
-    where 
-        b n = if (testBit f n) then "1" else "0"
+import Data.Bits (testBit, setBit)
+import Numeric (readHex)
 
 stepper :: FrozenCPUEnvironment -> Cycles -> IO ()
 stepper cpuState cycles = do
@@ -44,17 +30,32 @@ stepper cpuState cycles = do
         "" -> doStepFunc runStep
         "QUIT" -> putStrLn "Byee"
         "MEM"  -> putStrLn "Address: " >> readLn >>= printMem cpuState >> retry
-        "RUN_TO" -> putStrLn "PC: " >> readLn >>= runToPc 
+        "REQUEST_VBLANK" -> requestVBlank
+        "STACK" -> putStrLn (viewStack cpuState) >> retry
+        "RUN_TO" -> putStrLn "PC: " >> readLn >>= runToPc
+        "RUN_FOR" -> putStrLn "Cycles: " >> readLn >>= runForCycles 
         "DUMP_VRAM" -> dumpVRAM cpuState >> retry
         _ -> putStrLn "Unknown command" >> retry
     
     where
         retry = stepper cpuState cycles
-        printMem cpu addr = putStrLn $ printf "[0x%02X] 0x%02X" addr (frz_rom00 cpu ! addr)
+        requestVBlank = stepper (setVBlankBit cpuState) cycles   
+        printMem cpu addr = putStrLn $ printf "[0x%02X] 0x%02X" addr (readFrzMemory addr cpu)
         runToPc breakpoint = doStepFunc $ runCpu $ stepWhile (testPc (/= breakpoint))
+        runForCycles num = doStepFunc $ runCpu $ stepWhileCycles (<= num)
         doStepFunc f =   
             let (nextState, extraCycles) = f cpuState
             in stepper nextState (cycles + extraCycles)
+
+-- Pretty dodgy but meh
+setVBlankBit :: FrozenCPUEnvironment -> FrozenCPUEnvironment
+setVBlankBit cpu = 
+    let 
+        int_reqs = readFrzMemory 0xFF0F cpu
+    in
+        cpu {
+            frz_ioports = (frz_ioports cpu)//[(0xFF0F, int_reqs `setBit` 0)]
+        }
 
 testPc :: (Register16 -> Bool) -> (CPU s Bool)
 testPc f = readReg pc >>= return.f
@@ -63,15 +64,26 @@ type StopCondition s = CPU s Bool
 type CycleCountedComputation s = CPU s Int
 
 stepWhile :: forall s. StopCondition s -> CycleCountedComputation s
-stepWhile condition = 
-    stepWhile' condition 0
+stepWhile condition = stepWhile' 0
     where 
-        stepWhile' condition sum = do
+        stepWhile' sum = do
             continue <- condition
             if continue then
-                step >>= \cycles -> stepWhile' condition (sum + cycles)
+                step >>= stepWhile' . (sum +)
             else
                 return sum
+
+stepUntil :: forall s. StopCondition s -> CycleCountedComputation s
+stepUntil condition = 
+    stepWhile (liftM not condition)
+
+stepWhileCycles :: (Int -> Bool) -> CycleCountedComputation s
+stepWhileCycles condition = 
+    stepWhileCycles' 0
+    where 
+        stepWhileCycles' sum 
+            | condition sum = step >>= stepWhileCycles' . (sum +)
+            | otherwise     = return sum
 
 runCpu :: (forall s. CycleCountedComputation s) -> FrozenCPUEnvironment -> (FrozenCPUEnvironment, Cycles)
 runCpu computation initialEnv = 

--- a/flailing-gameboy-emulator.cabal
+++ b/flailing-gameboy-emulator.cabal
@@ -21,7 +21,9 @@ library
                      , CPU.FrozenEnvironment
                      , CPU.Environment
                      , CPU.Instructions
+                     , CPU.Interrupts
                      , CPURunner
+                     , Viewers
   other-modules:       BitTwiddling
                      , ShowHex
                      , CPU.Flags
@@ -30,6 +32,7 @@ library
                      , array
                      , mtl
                      , bytestring
+                     , cond
   default-language:    Haskell2010
 
 executable gameboy-debugger-exe

--- a/flailing-gameboy-emulator.cabal
+++ b/flailing-gameboy-emulator.cabal
@@ -28,6 +28,7 @@ library
                      , ShowHex
                      , CPU.Flags
                      , CPU.Arithmetic
+                     , CPU.IORegisters
   build-depends:       base >= 4.7 && < 5
                      , array
                      , mtl

--- a/src/BitTwiddling.hs
+++ b/src/BitTwiddling.hs
@@ -1,5 +1,6 @@
 module BitTwiddling (
-    joinBytesM
+    joinBytes
+  , joinBytesM
   , to16
   , to8
   , toBytes

--- a/src/BitTwiddling.hs
+++ b/src/BitTwiddling.hs
@@ -1,6 +1,7 @@
 module BitTwiddling (
     joinBytes
   , joinBytesM
+  , flipBytes
   , to16
   , to8
   , toBytes
@@ -30,6 +31,11 @@ joinBytes low high =
         high16 = shiftL (to16 high) 8
     in
         high16 + low16
+
+flipBytes :: Word16 -> Word16
+flipBytes w =
+    let (low, high) = toBytes w
+    in joinBytes high low
 
 joinBytesM :: (Monad m) => m Word8 -> m Word8 -> m Word16
 joinBytesM = liftM2 joinBytes

--- a/src/CPU/Environment.hs
+++ b/src/CPU/Environment.hs
@@ -17,7 +17,13 @@ import Data.STRef
 import Data.Array.ST
 import Control.Monad.ST as ST
 
-type MemoryBank s = (CPUEnvironment s -> STUArray s Address Word8)
+newtype MemoryBank s = MemoryBank {
+    array :: (CPUEnvironment s -> STUArray s Address Word8)
+}
+newtype IOBank s = IOBank {
+    array :: (CPUEnvironment s -> STUArray s Address Word8)
+}
+
 type CPURegister s w = (CPUEnvironment s -> STRef s w)
 
 -- The whole state of the CPU and all the memory.
@@ -35,16 +41,16 @@ data CPUEnvironment s = CPUEnvironment {
   , sp :: STRef s Register16
   , pc :: STRef s Register16
   -- Memory banks:
-  , rom00 :: STUArray s Address Word8
-  , rom01 :: STUArray s Address Word8
-  , vram :: STUArray s Address Word8
-  , extram :: STUArray s Address Word8
-  , wram0 :: STUArray s Address Word8
-  , wram1 :: STUArray s Address Word8
-  , oam :: STUArray s Address Word8
-  , ioports :: STUArray s Address Word8
-  , hram :: STUArray s Address Word8
-  , iereg :: STUArray s Address Word8
+  , rom00 :: MemoryBank s
+  , rom01 :: MemoryBank s
+  , vram :: MemoryBank s
+  , extram :: MemoryBank s
+  , wram0 :: MemoryBank s
+  , wram1 :: MemoryBank s
+  , oam :: MemoryBank s
+  , ioports :: IOBank s
+  , hram :: MemoryBank s
+  , iereg :: MemoryBank s
   -- Master interrupt flag
   , ime :: STRef s Bool
 }
@@ -77,9 +83,16 @@ resumeCPU state = do
     ime <- newSTRef $ frz_ime state
     return CPUEnvironment { 
         a = a, f = f, b = b, c = c, d = d, e = e, h = h, l = l, sp = sp, pc = pc 
-      , rom00 = rom00, rom01 = rom01, vram = vram, extram = extram
-      , wram0 = wram0, wram1 = wram1, oam = oam, ioports = ioports, hram = hram
-      , iereg = iereg
+      , rom00 = MemoryBank { array=rom00 }
+      , rom01 = MemoryBank { array=rom01 }
+      , vram = MemoryBank { array=vram }
+      , extram = MemoryBank { array=extram }
+      , wram0 = MemoryBank { array=wram0 }
+      , wram1 = MemoryBank { array=wram1 }
+      , oam = MemoryBank { array=oam }
+      , ioports = IOBank { array=ioports }
+      , hram = MemoryBank { array=hram }
+      , iereg = MemoryBank { array=iereg }
       , ime = ime
     }
 

--- a/src/CPU/Environment.hs
+++ b/src/CPU/Environment.hs
@@ -45,6 +45,8 @@ data CPUEnvironment s = CPUEnvironment {
   , ioports :: STUArray s Address Word8
   , hram :: STUArray s Address Word8
   , iereg :: STUArray s Address Word8
+  -- Master interrupt flag
+  , ime :: STRef s Bool
 }
 
 initCPU :: Memory -> ST s (CPUEnvironment s)
@@ -72,11 +74,13 @@ resumeCPU state = do
     l  <- newSTRef $ frz_l state
     sp <- newSTRef $ frz_sp state
     pc <- newSTRef $ frz_pc state
+    ime <- newSTRef $ frz_ime state
     return CPUEnvironment { 
         a = a, f = f, b = b, c = c, d = d, e = e, h = h, l = l, sp = sp, pc = pc 
       , rom00 = rom00, rom01 = rom01, vram = vram, extram = extram
       , wram0 = wram0, wram1 = wram1, oam = oam, ioports = ioports, hram = hram
       , iereg = iereg
+      , ime = ime
     }
 
 pauseCPU :: CPUEnvironment s -> ST s FrozenCPUEnvironment
@@ -101,6 +105,7 @@ pauseCPU cpu = do
     f_l  <- readSTRef $ l cpu
     f_sp <- readSTRef $ sp cpu
     f_pc <- readSTRef $ pc cpu
+    f_ime <- readSTRef $ ime cpu
     return FrozenCPUEnvironment { 
         frz_a = f_a, frz_f = f_f, frz_b = f_b, frz_c = f_c
       , frz_d = f_d, frz_e = f_e, frz_h = f_h, frz_l = f_l
@@ -108,6 +113,7 @@ pauseCPU cpu = do
       , frz_rom00 = f_rom00, frz_rom01 = f_rom01, frz_vram = f_vram, frz_extram = f_extram
       , frz_wram0 = f_wram0, frz_wram1 = f_wram1, frz_oam = f_oam, frz_ioports = f_ioports, frz_hram = f_hram
       , frz_iereg = f_iereg
+      , frz_ime = f_ime
     }
 
 -- Each pair of 8-bit registers can be accessed 

--- a/src/CPU/Environment.hs
+++ b/src/CPU/Environment.hs
@@ -20,9 +20,6 @@ import Control.Monad.ST as ST
 newtype MemoryBank s = MemoryBank {
     array :: (CPUEnvironment s -> STUArray s Address Word8)
 }
-newtype IOBank s = IOBank {
-    array :: (CPUEnvironment s -> STUArray s Address Word8)
-}
 
 type CPURegister s w = (CPUEnvironment s -> STRef s w)
 

--- a/src/CPU/FrozenEnvironment.hs
+++ b/src/CPU/FrozenEnvironment.hs
@@ -1,11 +1,13 @@
 module CPU.FrozenEnvironment (
     FrozenCPUEnvironment(..)
   , defaultCPU
+  , readFrzMemory
     ) where
 
 import CPU.Types
 import Data.Word
 import Data.Array
+import ShowHex (showHex)
 
 zeroMemory :: (Word16,Word16) -> Array Word16 Word8
 zeroMemory (minIndex, maxIndex) =
@@ -34,6 +36,8 @@ data FrozenCPUEnvironment = FrozenCPUEnvironment {
   , frz_ioports :: Array Address Word8
   , frz_hram :: Array Address Word8
   , frz_iereg :: Array Address Word8
+  -- Master interrupt flag
+  , frz_ime :: Bool
 } deriving (Show)
 
 defaultCPU :: FrozenCPUEnvironment
@@ -48,14 +52,40 @@ defaultCPU = FrozenCPUEnvironment {
   , frz_ioports = zeroMemory (0xFF00, 0xFF7F)
   , frz_hram    = zeroMemory (0xFF80, 0xFFFE)
   , frz_iereg   = zeroMemory (0xFFFF, 0xFFFF)
-  , frz_a  = 0x00
-  , frz_f  = 0x00
+  , frz_a  = 0x01
+  , frz_f  = 0xB0
   , frz_b  = 0x00
-  , frz_c  = 0x00
+  , frz_c  = 0x13
   , frz_d  = 0x00
-  , frz_e  = 0x00
-  , frz_h  = 0x00
-  , frz_l  = 0x00
-  , frz_sp = 0x00
+  , frz_e  = 0xD8
+  , frz_h  = 0x01
+  , frz_l  = 0x4D
+  , frz_sp = 0xFFFE
   , frz_pc = 0x100
+  , frz_ime = True
 } 
+
+-- The memory map is divided into different banks. 
+-- Get the bank that this address points to.
+-- Some banks are switchable - these are not yet dealt with.
+memoryBank :: Address -> (FrozenCPUEnvironment -> Array Address Word8)
+memoryBank addr
+    | addr < 0x4000 = frz_rom00   -- 16KB Fixed cartridge rom bank.
+    | addr < 0x8000 = frz_rom01   -- 16KB Switchable cartridge rom bank.
+    | addr < 0xA000 = frz_vram    -- 8KB Video RAM.
+    | addr < 0xC000 = frz_extram  -- 8KB Switchable RAM in cartridge.
+    | addr < 0xD000 = frz_wram0   -- 4KB Work RAM.
+    | addr < 0xE000 = frz_wram1   -- 4KB Work RAM.
+    | addr < 0xFE00 = error $ "Memory access at " ++ (showHex addr) ++ ". " ++
+                              "This is an 'echo' address. Not implemented yet :("
+    | addr < 0xFEA0 = frz_oam     -- Sprite Attribute Table
+    | addr < 0xFF00 = error $ "Memory access at unusable address: " ++ (showHex addr)
+    | addr < 0xFF80 = frz_ioports -- IO ports
+    | addr < 0xFFFF = frz_hram    -- 127 byte High RAM
+    | addr == 0xFFFF = frz_iereg  -- Interrupt Enable register.
+
+
+readFrzMemory :: Address -> FrozenCPUEnvironment -> Word8
+readFrzMemory addr env = 
+    (memoryBank addr) env ! addr
+

--- a/src/CPU/FrozenEnvironment.hs
+++ b/src/CPU/FrozenEnvironment.hs
@@ -5,6 +5,7 @@ module CPU.FrozenEnvironment (
     ) where
 
 import CPU.Types
+import qualified CPU.IORegisters as GBIO
 import Data.Word
 import Data.Array
 import ShowHex (showHex)
@@ -33,7 +34,7 @@ data FrozenCPUEnvironment = FrozenCPUEnvironment {
   , frz_wram0 :: Array Address Word8
   , frz_wram1 :: Array Address Word8
   , frz_oam :: Array Address Word8
-  , frz_ioports :: Array Address Word8
+  , frz_ioports :: GBIO.FrozenIORegisters
   , frz_hram :: Array Address Word8
   , frz_iereg :: Array Address Word8
   -- Master interrupt flag
@@ -49,9 +50,9 @@ defaultCPU = FrozenCPUEnvironment {
   , frz_wram0   = zeroMemory (0xC000, 0xCFFF)
   , frz_wram1   = zeroMemory (0xD000, 0xDFFF)
   , frz_oam     = zeroMemory (0xFE00, 0xFE9F)
-  , frz_ioports = zeroMemory (0xFF00, 0xFF7F)
   , frz_hram    = zeroMemory (0xFF80, 0xFFFE)
   , frz_iereg   = zeroMemory (0xFFFF, 0xFFFF)
+  , frz_ioports = GBIO.create
   , frz_a  = 0x01
   , frz_f  = 0xB0
   , frz_b  = 0x00
@@ -80,7 +81,7 @@ memoryBank addr
                               "This is an 'echo' address. Not implemented yet :("
     | addr < 0xFEA0 = frz_oam     -- Sprite Attribute Table
     | addr < 0xFF00 = error $ "Memory access at unusable address: " ++ (showHex addr)
-    | addr < 0xFF80 = frz_ioports -- IO ports
+    | addr < 0xFF80 = error $ "Remind me to implement access to the IO ports"
     | addr < 0xFFFF = frz_hram    -- 127 byte High RAM
     | addr == 0xFFFF = frz_iereg  -- Interrupt Enable register.
 

--- a/src/CPU/IORegisters.hs
+++ b/src/CPU/IORegisters.hs
@@ -1,0 +1,18 @@
+module CPU.IORegisters (
+    IORegisters(..)
+) where
+
+lcdScanline :: Int -> Int
+lcdScanline cycles = 
+    | modcycles <= 29172 = modcycles `div` 204
+    | modcycles <= 33732 = ((modcycles - 29172) `div` 456) + 143
+    | otherwise          = 0
+    where
+        modcycles = cycles `mod` 33984
+
+
+data IORegisters = IORegisters {
+    elapsedCycles :: STRef s Int
+}
+
+

--- a/src/CPU/IORegisters.hs
+++ b/src/CPU/IORegisters.hs
@@ -1,18 +1,117 @@
 module CPU.IORegisters (
-    IORegisters(..)
+    IORegisters,
+    FrozenIORegisters,
+    create,
+    thaw,
+    freeze,
+    addCycles,
+    readPort,
+    writePort
 ) where
 
-lcdScanline :: Int -> Int
-lcdScanline cycles = 
-    | modcycles <= 29172 = modcycles `div` 204
-    | modcycles <= 33732 = ((modcycles - 29172) `div` 456) + 143
-    | otherwise          = 0
-    where
-        modcycles = cycles `mod` 33984
+import CPU.Types (Address)
+import Data.Word (Word8)
+import Data.STRef (STRef(..), readSTRef, writeSTRef)
+import Control.Monad.ST
+import Text.Printf (printf)
 
-
-data IORegisters = IORegisters {
+-- IO registers act like normal memory locations from the point of view
+-- of most gameboy instructions.
+-- However, they are not real memory.
+-- Reading from and writing to these addresses is how gameboy programs
+-- interact with the hardware.
+-- 
+-- This structure will keep all of the actual state needed to keep track
+-- of the hardware.
+-- Right now, that just means the number of cycles elapsed.
+data IORegisters s = IORegisters {
     elapsedCycles :: STRef s Int
 }
+--
+-- Let's have a handy access function for the number of cycles
+cycles :: IORegisters s -> ST s Int
+cycles io = readSTRef (elapsedCycles io)
+--
+-- And I need a frozen version for outside of the CPU monad.
+data FrozenIORegisters = FrozenIORegisters {
+    frz_elapsedCycles :: Int
+}
+-- (Maybe I can generate this pair with some template haskell?)
+--
+----- Construction
+--
+-- Of course, we start with zero cycles!
+create :: FrozenIORegisters
+create = FrozenIORegisters { frz_elapsedCycles = 0 }
+--
+thaw :: FrozenIORegisters -> ST s (IORegisters s)
+thaw frzio =
+    newSTRef (frz_elapsedCycles frzio) >>=
+    return . IORegisters
+--
+freeze :: IORegisters s -> ST s FrozenIORegisters
+freeze io =
+    cycles io >>= 
+    return . FrozenIORegisters
+--
+----- Updates
+--
+-- We need to keep track of extra cycles whenver we execute instructions
+addCycles :: IORegisters s -> Int -> ST s ()
+addCycles io newCycles = do
+    current <- cycles io
+    writeSTRef (elapsedCycles io) (current + newCycles) 
+--
+----- Access
+--
+-- Here's our main memory reading function.
+-- Eventually, this will be the whole IO map.
+-- Right now I've just the LCD Y register.
+readPort :: Address -> IORegisters s -> ST s Word8 
+readPort addr io
+    | isIOPort addr =
+        case addr of
+            0xFF44 -> lcdYCoordinate io
+            _      -> return 0x00 -- Default placeholder until all ports implemented
+    | otherwise = 
+        error $ printf "Address 0x%04X is not an IO port" addr  
+--
+-- And the corresponding map for writing...
+-- Most IO registers are read-only. Some of them are reset to zero upon writing.
+-- A few can genuinely be written to.
+-- As a first implementation, it seemed safest to do nothing.
+writePort :: Address -> IORegisters s -> ST s ()
+writePort addr _ 
+    | isIOPort addr = return ()
+    | otherwise = 
+        error $ printf "Address 0x%04X is not an IO port" addr   
+--
+-- IO Ports are the memory range from 0xFF00 through 0xFF7F
+isIOPort :: Address -> Bool
+isIOPort addr = 
+    addr >= 0xFF00 && addr < 0xFF80
+--
+-- 0xFF44: The current scanline being written to by the LCD driver.
+--   Scanlines from 144 to 153 indicate the vblank period.
+lcdYCoordinate :: IORegisters s -> ST s Word8
+lcdYCoordinate io = 
+    cycles io >>= 
+    return . fromIntegral . lcdScanline
 
+-- The LCD refreshes the screen one line at a time,
+-- like this:
+--   Lines 0 - 143 each take 204 cycles
+--   Lines 144 - 153 each take 456 cycles. This is the VBlank period. These lines can't be seen.
+--   Finally, there are 252 cycles before line 0 starts again.
+lcdScanline :: Int -> Int
+lcdScanline elapsedCycles
+    | modCycles <= hBlankCycles = modCycles `div` 20
+    | modCycles <= totalCycles  = ((modCycles - hBlankCycles) `div` 456) + 143
+    | otherwise                 = 0
+    where
+        hBlankCycles = 143 * 204
+        vBlankCycles =  10 * 456
+        otherCycles  = 252
+        totalCycles  = hBlankCycles + vBlankCycles + otherCycles
+        modCycles    = elapsedCycles `mod` totalCycles
 

--- a/src/CPU/Instructions.hs
+++ b/src/CPU/Instructions.hs
@@ -1,6 +1,5 @@
 module CPU.Instructions (
     execute
-  , step
     ) where
 
 import BitTwiddling
@@ -12,10 +11,7 @@ import CPU
 import ShowHex
 
 import qualified Data.Bits as Bit
-import Data.Word
-
-step :: CPU s Cycles
-step = fetch >>= execute
+import Data.Word    
 
 execute :: Opcode -> CPU s Cycles
 execute op = case op of
@@ -178,4 +174,6 @@ jr cc byte = do
 
 -- DI: Disable interrupts
 di :: CPU s Cycles
-di = return 4 -- Haven't implemented interrupts yet.
+di = 
+    disableMasterInterrupt >> 
+    return 4 

--- a/src/CPU/Instructions.hs
+++ b/src/CPU/Instructions.hs
@@ -13,6 +13,12 @@ import ShowHex
 import qualified Data.Bits as Bit
 import Data.Word    
 
+-- For reasons I haven't completely figured out yet,
+-- the arguments to the combo register instructions are flipped.
+-- This does NOT affect jump instructions.
+-- TODO: Investigate gameboy endianness.
+
+
 execute :: Opcode -> CPU s Cycles
 execute op = case op of
     0x00 -> nop

--- a/src/CPU/Interrupts.hs
+++ b/src/CPU/Interrupts.hs
@@ -7,16 +7,16 @@ module CPU.Interrupts (
 -- They are triggered by the hardware when something significant happens.
 
 import CPU (
-    CPU(..), 
-    readMemory, 
-    modifyMemory,
-    readReg,
-    writeReg, 
-    pushOntoStack, 
-    jumpTo, 
-    isMasterInterruptEnabled,
-    disableMasterInterrupt 
-)
+    CPU
+  , readMemory
+  , modifyMemory
+  , readReg
+  , writeReg 
+  , pushOntoStack 
+  , jumpTo
+  , isMasterInterruptEnabled
+  , disableMasterInterrupt 
+  )
 import CPU.Environment (pc)
 import CPU.Types (Address)
 import Data.Bits (setBit, clearBit, testBit)

--- a/src/CPU/Interrupts.hs
+++ b/src/CPU/Interrupts.hs
@@ -1,0 +1,92 @@
+module CPU.Interrupts (
+    runInterrupts
+) where
+
+----- Interrupts -----
+-- An interrupt is when the program is suddenly sent to a different place.
+-- They are triggered by the hardware when something significant happens.
+
+import CPU (
+    CPU(..), 
+    readMemory, 
+    modifyMemory,
+    readReg,
+    writeReg, 
+    pushOntoStack, 
+    jumpTo, 
+    isMasterInterruptEnabled,
+    disableMasterInterrupt )
+import CPU.Environment (pc)
+import CPU.Types (Address)
+import Data.Bits (setBit, clearBit, testBit)
+import Control.Conditional (ifM, (<&&>))
+
+data Interrupt = Interrupt Int Address
+-----------------------------------------
+vBlank  = Interrupt 0 0x40    -- After the screen has finished drawing
+lcdStat = Interrupt 1 0x48        
+timer   = Interrupt 2 0x50
+serial  = Interrupt 3 0x58
+joypad  = Interrupt 4 0x60
+
+----- Interrupt Master Enable
+--
+-- Firstly, no interrupts will ever happen unless the IME is on.
+
+----- Interrupt Flags
+--
+interruptEnable = 0xFFFF
+-- The byte at 0xFFFF represents the _interrupt enable_ flags.
+-- If an interrupt's bit is set to 0, the interrupt does not happen.
+--
+interruptRequest = 0xFF0F
+-- The byte at 0xFF0F represents _interrupt requests_.
+-- If an interrupt's byte is set, the interrupt should happen 
+-- after the next opcode is executed.
+--
+-- As far as I know, if multiple interrupts are waiting, 
+-- only the first one is handled, with this priority:
+interruptsByPriority = [vBlank, lcdStat, timer, serial, joypad]
+--
+-- It is possible for an interrupt to happen during another interrupt.
+
+testMemoryBit address bit  = fmap (`testBit` bit) (readMemory address) 
+setMemoryBit address bit   = modifyMemory address (`setBit` bit)
+clearMemoryBit address bit = modifyMemory address (`clearBit` bit)
+
+setInterruptEnable   :: Int -> CPU s ()
+resetInterruptEnable :: Int -> CPU s ()
+testInterruptEnabled :: Int -> CPU s Bool
+setInterruptEnable   = setMemoryBit interruptEnable
+resetInterruptEnable = clearMemoryBit interruptEnable
+testInterruptEnabled = testMemoryBit interruptEnable
+
+setInterruptRequest   :: Int -> CPU s ()
+resetInterruptRequest :: Int -> CPU s ()
+testInterruptRequested :: Int -> CPU s Bool
+setInterruptRequest   = setMemoryBit interruptRequest
+resetInterruptRequest = clearMemoryBit interruptRequest
+testInterruptRequested = testMemoryBit interruptRequest
+
+shouldRun :: Interrupt -> CPU s Bool
+shouldRun (Interrupt bit _) =
+    ifM (isMasterInterruptEnabled)
+        ((testInterruptEnabled bit) <&&> (testInterruptRequested bit))
+        (return False)
+
+runInterrupts :: CPU s ()
+runInterrupts = tryRemainingInterrupts interruptsByPriority
+    where
+        tryRemainingInterrupts [] = return ()
+        tryRemainingInterrupts (interrupt : remainder) =
+            ifM (shouldRun interrupt)
+                (interruptRoutine interrupt)
+                (tryRemainingInterrupts remainder)
+
+-- This is what happens when an interrupt is triggered: 
+interruptRoutine :: Interrupt -> CPU s ()
+interruptRoutine (Interrupt bit handler) = do
+    disableMasterInterrupt 
+    resetInterruptRequest bit
+    readReg pc >>= pushOntoStack
+    jumpTo handler

--- a/src/CPURunner.hs
+++ b/src/CPURunner.hs
@@ -1,12 +1,21 @@
 {-# LANGUAGE Rank2Types #-}
 
 module CPURunner (
-    runCPUTest
+    runCPUTest,
+    step
     ) where
 
 import CPU
-import CPU.Types
+import CPU.Instructions
+import CPU.Interrupts
+import CPU.Types 
 import Control.Monad.ST
 
 runCPUTest :: (forall s. CPU s a) -> Memory -> a
 runCPUTest f rom = runST $ initCPU rom >>= runCPU f
+
+step :: CPU s Cycles
+step = do
+    cycles <- (fetch >>= execute)
+    runInterrupts
+    return cycles

--- a/src/CPURunner.hs
+++ b/src/CPURunner.hs
@@ -12,10 +12,11 @@ import CPU.Types
 import Control.Monad.ST
 
 runCPUTest :: (forall s. CPU s a) -> Memory -> a
-runCPUTest f rom = runST $ initCPU rom >>= runCPU f
+runCPUTest f rom = runST $ initCPU rom >>= runCPU f    
 
 step :: CPU s Cycles
 step = do
     cycles <- (fetch >>= execute)
+    updateMachineTicks cycles
     runInterrupts
     return cycles

--- a/src/Viewers.hs
+++ b/src/Viewers.hs
@@ -1,0 +1,69 @@
+module Viewers (
+    viewCPU
+  , viewStack
+  , viewMem
+  , viewMem16
+) where
+
+import CPU.FrozenEnvironment (FrozenCPUEnvironment(..), readFrzMemory)
+import CPU.Types (Address)
+import BitTwiddling (joinBytes)
+import Text.Printf (printf)
+import Data.Word (Word8, Word16)
+import Data.Bits (testBit)
+import Data.Array ((!))
+
+-- A basic view showing the registers, flags and the next instruction:
+--
+--     A F  B C  D E  H L   SP
+--     01B0 0013 00D8 014D FFFE
+--
+--                       IME : ENABLED
+--     Flags ZNHC         
+--           1011          
+--
+--     PC = 0x0100 (0x00)
+--
+viewCPU :: FrozenCPUEnvironment -> String
+viewCPU cpu = 
+            "A F  B C  D E  H L   SP \n" ++
+    (printf "%02X%02X %02X%02X %02X%02X %02X%02X %04X\n\n" 
+        (frz_a cpu) (frz_f cpu) (frz_b cpu) (frz_c cpu) (frz_d cpu) (frz_e cpu) (frz_h cpu) (frz_l cpu) (frz_sp cpu)) ++
+    ("                  IME: " ++ (if frz_ime cpu then "ENABLED" else "DISABLED")) ++ "\n" ++
+    (viewFlags $ frz_f cpu) ++
+    "\n" ++
+    (printf "PC = 0x%04X (0x%02X)\n" (frz_pc cpu) (frz_rom00 cpu ! (frz_pc cpu)))
+
+viewFlags :: Word8 -> String
+viewFlags f = 
+    "Flags ZNHC \n" ++ 
+    "      " ++ (b 7) ++ (b 6) ++ (b 5) ++ (b 4) ++ "\n"
+    where 
+        b n = if (testBit f n) then "1" else "0"
+
+readMem16 :: Address -> FrozenCPUEnvironment -> Word16
+readMem16 address cpu = 
+    let
+        low = readFrzMemory address cpu
+        high = readFrzMemory (address + 1) cpu
+    in
+        joinBytes low high
+
+viewMem16 :: Address -> FrozenCPUEnvironment -> String
+viewMem16 address cpu = 
+    printf "0x%04X" $ readMem16 address cpu 
+
+viewMem :: Address -> FrozenCPUEnvironment -> String
+viewMem address cpu = 
+    printf "0x%02X" $ readFrzMemory address cpu
+
+viewStack :: FrozenCPUEnvironment -> String
+viewStack cpu =
+    (traceStackFrom 0xFFFE) ++ (showPointer)
+    where
+        pointer = frz_sp cpu
+        showPointer = printf "[    ] <- 0x%04X\n" pointer
+        traceStackFrom address 
+            | address > pointer = (viewMem16 address cpu) ++ "\n" ++ 
+                                  (traceStackFrom (address - 2))
+            | otherwise = ""

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,8 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps: 
+- cond-0.4.1.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Some significant refactoring and commenting but basically I implemented the IO Ports.
This is a separate section of memory which is not really memory. It gives you various interactions with the hardware.
The first one I needed to get tetris going was the Y location of the LCD scanlines, at 0xFF44.
